### PR TITLE
[#3] Add extract function for a subset of a byte array

### DIFF
--- a/bytearray_operations.go
+++ b/bytearray_operations.go
@@ -1,27 +1,68 @@
 package gobits
 
+import "math"
+
 // RightShift apply right shift operation to byte array data
-func RightShift(data []byte, shift uint8) []byte {
+func RightShift(data []byte, shift uint64) []byte {
+	if shift == 0 {
+		return data
+	}
 	var dataLength = len(data)
 	result := make([]byte, dataLength)
-	for i := dataLength - 1; i >= 0; i-- {
-		if i > 0 {
-			result[i-1] = data[i] >> (byteLength - shift)
+	if shift > byteLength {
+		copy(result, data[1:])
+		result = RightShift(result, shift-byteLength)
+	} else {
+		for i := dataLength - 1; i >= 0; i-- {
+			if i > 0 {
+				result[i-1] = data[i] >> (byteLength - shift)
+			}
+			result[i] = result[i] | (data[i] << shift)
 		}
-		result[i] = result[i] | (data[i] << shift)
 	}
 	return result
 }
 
 // LeftShift apply left shift operation to byte array data
-func LeftShift(data []byte, shift uint8) []byte {
+func LeftShift(data []byte, shift uint64) []byte {
+	if shift == 0 {
+		return data
+	}
 	var dataLength = len(data)
 	result := make([]byte, dataLength)
-	for i := 0; i < dataLength; i++ {
-		if i < dataLength-1 {
-			result[i+1] = data[i] << (byteLength - shift)
+	if shift > byteLength {
+		var shiftedData = append(make([]byte, 1), data[:dataLength-1]...)
+		result = LeftShift(shiftedData, shift-byteLength)
+	} else {
+		for i := 0; i < dataLength; i++ {
+			if i < dataLength-1 {
+				result[i+1] = data[i] << (byteLength - shift)
+			}
+			result[i] = result[i] | (data[i] >> shift)
 		}
-		result[i] = result[i] | (data[i] >> shift)
 	}
 	return result
+}
+
+// ExtractBytes get a byte array as subset of another byte array
+func ExtractBytes(data []byte, lsbPosition, msbPosition uint64) []byte {
+	var maxMsb = uint64(byteLength*len(data) - 1)
+
+	var result = RightShift(data, maxMsb-msbPosition)
+	var correctiveShift = maxMsb + lsbPosition - msbPosition
+	result = LeftShift(result, correctiveShift)
+
+	var size = ComputeSize(lsbPosition, msbPosition)
+	return Trim(result, size)
+}
+
+// ComputeSize compute size from 2 bit positions
+func ComputeSize(lsbPosition, msbPosition uint64) uint64 {
+	var byteCount = float64(msbPosition-lsbPosition) / float64(byteLength)
+	return uint64(math.Ceil(byteCount))
+}
+
+// Trim get a trim byte array as subset of another byte array
+func Trim(data []byte, newSize uint64) []byte {
+	return data[uint64(len(data))-newSize:]
 }

--- a/bytearray_operations_test.go
+++ b/bytearray_operations_test.go
@@ -12,9 +12,65 @@ func TestRightShift(t *testing.T) {
 	}
 }
 
+func TestRightShiftOver1Byte(t *testing.T) {
+	var result = RightShift([]byte{0x99, 0xBA}, 9)
+	if !reflect.DeepEqual(result, []byte{0x74, 0x00}) {
+		t.Errorf("RightShiftOver1Byte don't work: %x", result)
+	}
+}
+
 func TestLeftShift(t *testing.T) {
 	var result = LeftShift([]byte{0x99, 0xBA}, 1)
 	if !reflect.DeepEqual(result, []byte{0x4C, 0xDD}) {
 		t.Errorf("LeftShift don't work: %x", result)
+	}
+}
+
+func TestLeftShiftOver1Byte(t *testing.T) {
+	var result = LeftShift([]byte{0x99, 0xBA}, 9)
+	if !reflect.DeepEqual(result, []byte{0x00, 0x4C}) {
+		t.Errorf("LeftShiftOver1Byte don't work: %x", result)
+	}
+}
+
+func TestExtract1ByteFrom2Bytes(t *testing.T) {
+	var result = ExtractBytes([]byte{0x99, 0xBA}, 7, 8)
+	if !reflect.DeepEqual(result, []byte{0x03}) {
+		t.Errorf("Extract1ByteFrom2Bytes don't work: %x", result)
+	}
+}
+
+func TestExtract1ByteFrom3Bytes(t *testing.T) {
+	var result = ExtractBytes([]byte{0x99, 0xBA, 0xDE}, 15, 16)
+	if !reflect.DeepEqual(result, []byte{0x03}) {
+		t.Errorf("Extract1ByteFrom3Bytes don't work: %x", result)
+	}
+}
+
+func TestExtract2ByteFrom3Bytes(t *testing.T) {
+	var result = ExtractBytes([]byte{0x99, 0xBA, 0xDE}, 8, 19)
+	if !reflect.DeepEqual(result, []byte{0x09, 0xBA}) {
+		t.Errorf("Extract2ByteFrom3Bytes don't work: %x", result)
+	}
+}
+
+func TestExtractAllBytes(t *testing.T) {
+	var result = ExtractBytes([]byte{0x99, 0xBA, 0xDE}, 0, 23)
+	if !reflect.DeepEqual(result, []byte{0x99, 0xBA, 0xDE}) {
+		t.Errorf("ExtractAllBytes don't work: %x", result)
+	}
+}
+
+func TestComputeSize(t *testing.T) {
+	var result = ComputeSize(8, 75)
+	if result != 9 {
+		t.Errorf("ComputeSize don't work: %d", result)
+	}
+}
+
+func TestTrim(t *testing.T) {
+	var result = Trim([]byte{0x99, 0xBA, 0x00, 0x02}, 2)
+	if !reflect.DeepEqual(result, []byte{0x00, 0x02}) {
+		t.Errorf("TestTrim don't work: %x", result)
 	}
 }


### PR DESCRIPTION
- RightShift learn to support shift greater than a byte size
- LeftShift learn to support shift greater than a byte size
- ExtractBytes is added
- ComputeSize is added
- Trim is added

Closes #3