### PR TITLE
[#26] Change tests/benchmarks to use subtests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,5 @@ before_install:
   - go get github.com/mattn/goveralls
 
 script:
+  - go test -v -bench=. ./...
   - $GOPATH/bin/goveralls -service=travis-ci

--- a/bit_operations_test.go
+++ b/bit_operations_test.go
@@ -1,147 +1,149 @@
 package gobits
 
-import "testing"
+import (
+	"testing"
+)
+
+var testcasesContainsBit = []struct {
+	name   string
+	data   byte
+	bit    uint8
+	result bool
+}{
+	{"hi in hi", 0xf0, 5, true},
+	{"lo in hi", 0xf0, 2, false},
+}
 
 func TestContainsBit(t *testing.T) {
 	var val bool
-	tests := []struct {
-		name   string
-		data   byte
-		bit    uint8
-		result bool
-	}{
-		{"hi in hi", 0xf0, 5, true},
-		{"lo in hi", 0xf0, 2, false},
-	}
-	for _, tt := range tests {
-
-		val = ContainsBit(tt.data, tt.bit)
-		if val != tt.result {
-			t.Errorf("Test '%v' failed: ContainsBit(0x%x, %v) was %v, should be %v",
-				tt.name,
-				tt.data, tt.bit,
-				val,
-				tt.result)
-		}
+	for _, tc := range testcasesContainsBit {
+		t.Run(tc.name, func(t *testing.T) {
+			val = ContainsBit(tc.data, tc.bit)
+			if val != tc.result {
+				t.Errorf("ContainsBit(%x, %v) was %v, should be %v",
+					tc.data, tc.bit,
+					val,
+					tc.result)
+			}
+		})
 	}
 }
 
-func BenchmarkContainsBitTrue(t *testing.B) {
-	for i := 0; i < t.N; i++ {
-		ContainsBits(0xf0, 5)
+func BenchmarkContainsBit(b *testing.B) {
+	var val bool
+	for _, tc := range testcasesContainsBit {
+		b.Run(tc.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				val = ContainsBit(tc.data, tc.bit)
+			}
+		})
 	}
 }
 
-func BenchmarkContainsBitFalse(t *testing.B) {
-	for i := 0; i < t.N; i++ {
-		ContainsBits(0xf0, 2)
-	}
+var testcasesSetBit = []struct {
+	name   string
+	data   byte
+	bit    uint8
+	result byte
+}{
+	{"set low bit", 0xf0, 0, 0xf1},
+	{"set already-set bit", 0xf0, 5, 0xf0},
 }
 
 func TestSetBit(t *testing.T) {
 	var val byte
-	tests := []struct {
-		name   string
-		data   byte
-		bit    uint8
-		result byte
-	}{
-		{"set low bit", 0xf0, 0, 0xf1},
-		{"set already-set bit", 0xf0, 5, 0xf0},
-	}
-	for _, tt := range tests {
-
-		val = SetBit(tt.data, tt.bit)
-		if val != tt.result {
-			t.Errorf("Test '%v' failed: SetBit(0x%x, %v) was 0x%x, should be 0x%x",
-				tt.name,
-				tt.data, tt.bit,
-				val,
-				tt.result)
-		}
+	for _, tc := range testcasesSetBit {
+		t.Run(tc.name, func(t *testing.T) {
+			val = SetBit(tc.data, tc.bit)
+			if val != tc.result {
+				t.Errorf("SetBit(%x, %v) was %x, should be %x",
+					tc.data, tc.bit,
+					val,
+					tc.result)
+			}
+		})
 	}
 }
 
-func BenchmarkSetBitLow(t *testing.B) {
-	for i := 0; i < t.N; i++ {
-		SetBit(0xf0, 0)
+func BenchmarkSetBit(b *testing.B) {
+	var val byte
+	for _, tc := range testcasesSetBit {
+		b.Run(tc.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				val = SetBit(tc.data, tc.bit)
+			}
+		})
 	}
 }
 
-func BenchmarkSetBitAlreadySet(t *testing.B) {
-	for i := 0; i < t.N; i++ {
-		SetBit(0xf0, 5)
-	}
+var testcasesUnsetBit = []struct {
+	name   string
+	data   byte
+	bit    uint8
+	result byte
+}{
+	{"unset high bit", 0xf0, 7, 0x70},
+	{"unset already-clear bit", 0xf0, 0, 0xf0},
 }
 
 func TestUnsetBit(t *testing.T) {
 	var val byte
-	tests := []struct {
-		name   string
-		data   byte
-		bit    uint8
-		result byte
-	}{
-		{"unset high bit", 0xf0, 7, 0x70},
-		{"unset already-clear bit", 0xf0, 0, 0xf0},
-	}
-	for _, tt := range tests {
-
-		val = UnsetBit(tt.data, tt.bit)
-		if val != tt.result {
-			t.Errorf("Test '%v' failed: UnsetBit(0x%x, %v) was 0x%x, should be 0x%x",
-				tt.name,
-				tt.data, tt.bit,
-				val,
-				tt.result)
-		}
+	for _, tc := range testcasesUnsetBit {
+		t.Run(tc.name, func(t *testing.T) {
+			val = UnsetBit(tc.data, tc.bit)
+			if val != tc.result {
+				t.Errorf("UnsetBit(%x, %v) was %x, should be %x",
+					tc.data, tc.bit,
+					val,
+					tc.result)
+			}
+		})
 	}
 }
 
-func BenchmarkUnsetBitHigh(t *testing.B) {
-	for i := 0; i < t.N; i++ {
-		UnsetBit(0xf0, 7)
+func BenchmarkUnsetBit(b *testing.B) {
+	var val byte
+	for _, tc := range testcasesUnsetBit {
+		b.Run(tc.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				val = UnsetBit(tc.data, tc.bit)
+			}
+		})
 	}
 }
 
-func BenchmarkUnsetBitAlreadyClear(t *testing.B) {
-	for i := 0; i < t.N; i++ {
-		UnsetBit(0xf0, 0)
-	}
+var testcasesGetBit = []struct {
+	name   string
+	data   byte
+	bit    uint8
+	result byte
+}{
+	{"get low bit of high nibble", 0xf0, 4, 0x10},
+	{"get low bit", 0xf0, 0, 0},
 }
 
 func TestGetBit(t *testing.T) {
 	var val byte
-	tests := []struct {
-		name   string
-		data   byte
-		bit    uint8
-		result byte
-	}{
-		{"get low bit of high nibble", 0xf0, 4, 0x10},
-		{"get low bit", 0xf0, 0, 0},
-	}
-	for _, tt := range tests {
-
-		val = GetBit(tt.data, tt.bit)
-		if val != tt.result {
-			t.Errorf("Test '%v' failed: GetBit(0x%x, %v) was 0x%x, should be 0x%x",
-				tt.name,
-				tt.data, tt.bit,
-				val,
-				tt.result)
-		}
+	for _, tc := range testcasesGetBit {
+		t.Run(tc.name, func(t *testing.T) {
+			val = GetBit(tc.data, tc.bit)
+			if val != tc.result {
+				t.Errorf("GetBit(%x, %v) was %x, should be %x",
+					tc.data, tc.bit,
+					val,
+					tc.result)
+			}
+		})
 	}
 }
 
-func BenchmarkGetBitHighNible(t *testing.B) {
-	for i := 0; i < t.N; i++ {
-		GetBit(0xf0, 4)
-	}
-}
-
-func BenchmarkGetBit(t *testing.B) {
-	for i := 0; i < t.N; i++ {
-		GetBit(0xf0, 0)
+func BenchmarkGetBit(b *testing.B) {
+	var val byte
+	for _, tc := range testcasesGetBit {
+		b.Run(tc.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				val = GetBit(tc.data, tc.bit)
+			}
+		})
 	}
 }

--- a/bits_operations_test.go
+++ b/bits_operations_test.go
@@ -2,157 +2,145 @@ package gobits
 
 import "testing"
 
+var testcasesContainsBits = []struct {
+	name       string
+	data, bits byte
+	result     bool
+}{
+	{"low in hi", 0xf0, 0x05, false},
+	{"hi in hi", 0xf0, 0x20, true},
+	{"split", 0xf0, 0x22, false},
+}
+
 func TestContainsBits(t *testing.T) {
 	var val bool
-	tests := []struct {
-		name       string
-		data, bits byte
-		result     bool
-	}{
-		{"low in hi", 0xf0, 0x05, false},
-		{"hi in hi", 0xf0, 0x20, true},
-		{"split", 0xf0, 0x22, false},
-	}
-	for _, tt := range tests {
-
-		val = ContainsBits(tt.data, tt.bits)
-		if val != tt.result {
-			t.Errorf("Test '%v' failed: ContainsBits(0x%x, 0x%x) was %v, should be %v",
-				tt.name,
-				tt.data, tt.bits,
-				val,
-				tt.result)
-		}
+	for _, tc := range testcasesContainsBits {
+		t.Run(tc.name, func(t *testing.T) {
+			val = ContainsBits(tc.data, tc.bits)
+			if val != tc.result {
+				t.Errorf("ContainsBits(%x, %x) was %v, should be %v",
+					tc.data, tc.bits,
+					val,
+					tc.result)
+			}
+		})
 	}
 }
 
-func BenchmarkContainsBitsTrue(t *testing.B) {
-	for i := 0; i < t.N; i++ {
-		ContainsBits(0xf0, 0x20)
+func BenchmarkContainsBits(b *testing.B) {
+	var val bool
+	for _, tc := range testcasesContainsBits {
+		b.Run(tc.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				val = ContainsBits(tc.data, tc.bits)
+			}
+		})
 	}
 }
 
-func BenchmarkContainsBitsFalse(t *testing.B) {
-	for i := 0; i < t.N; i++ {
-		ContainsBits(0xf0, 5)
-	}
-}
-
-func BenchmarkContainsBitsFalseSplit(t *testing.B) {
-	for i := 0; i < t.N; i++ {
-		ContainsBits(0xf0, 0x22)
-	}
+var testcasesSetBits = []struct {
+	name       string
+	data, bits byte
+	result     byte
+}{
+	{"set low bit", 0xf0, 0x00, 0xf0},
+	{"high and low", 0xf0, 0x11, 0xf1},
 }
 
 func TestSetBits(t *testing.T) {
 	var val byte
-	tests := []struct {
-		name       string
-		data, bits byte
-		result     byte
-	}{
-		{"set low bit", 0xf0, 0x00, 0xf0},
-		{"high and low", 0xf0, 0x11, 0xf1},
-	}
-	for _, tt := range tests {
-
-		val = SetBits(tt.data, tt.bits)
-		if val != tt.result {
-			t.Errorf("Test '%v' failed: SetBits(0x%x, 0x%x) was 0x%x, should be 0x%x",
-				tt.name,
-				tt.data, tt.bits,
-				val,
-				tt.result)
-		}
+	for _, tc := range testcasesSetBits {
+		t.Run(tc.name, func(t *testing.T) {
+			val = SetBits(tc.data, tc.bits)
+			if val != tc.result {
+				t.Errorf("SetBits(%x, %x) was %x, should be %x",
+					tc.data, tc.bits,
+					val,
+					tc.result)
+			}
+		})
 	}
 }
 
-func BenchmarkSetBitsLow(t *testing.B) {
-	for i := 0; i < t.N; i++ {
-		SetBits(0xf0, 0)
+func BenchmarkSetBits(b *testing.B) {
+	var val byte
+	for _, tc := range testcasesSetBits {
+		b.Run(tc.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				val = SetBits(tc.data, tc.bits)
+			}
+		})
 	}
 }
 
-func BenchmarkSetBitsHighLow(t *testing.B) {
-	for i := 0; i < t.N; i++ {
-		SetBits(0xf0, 0x11)
-	}
+var testcasesUnsetBits = []struct {
+	name       string
+	data, bits byte
+	result     byte
+}{
+	{"unset zero bit", 0xf0, 0x07, 0xf0},
+	{"unset some bits", 0xf0, 0x11, 0xe0},
 }
 
 func TestUnsetBits(t *testing.T) {
 	var val byte
-	tests := []struct {
-		name       string
-		data, bits byte
-		result     byte
-	}{
-		{"unset zero bit", 0xf0, 0x07, 0xf0},
-		{"unset some bits", 0xf0, 0x11, 0xe0},
-	}
-	for _, tt := range tests {
-
-		val = UnsetBits(tt.data, tt.bits)
-		if val != tt.result {
-			t.Errorf("Test '%v' failed: UnsetBits(0x%x, 0x%x) was 0x%x, should be 0x%x",
-				tt.name,
-				tt.data, tt.bits,
-				val,
-				tt.result)
-		}
+	for _, tc := range testcasesUnsetBits {
+		t.Run(tc.name, func(t *testing.T) {
+			val = UnsetBits(tc.data, tc.bits)
+			if val != tc.result {
+				t.Errorf("UnsetBits(%x, %x) was %x, should be %x",
+					tc.data, tc.bits,
+					val,
+					tc.result)
+			}
+		})
 	}
 }
 
-func BenchmarkUnsetBitsZeroBits(t *testing.B) {
-	for i := 0; i < t.N; i++ {
-		UnsetBits(0xf0, 7)
+func BenchmarkUnsetBits(b *testing.B) {
+	var val byte
+	for _, tc := range testcasesUnsetBits {
+		b.Run(tc.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				val = UnsetBits(tc.data, tc.bits)
+			}
+		})
 	}
 }
 
-func BenchmarkUnsetBitsSomeBits(t *testing.B) {
-	for i := 0; i < t.N; i++ {
-		UnsetBits(0xf0, 0x11)
-	}
+var testcasesExtractBits = []struct {
+	name                     string
+	data                     byte
+	lsbPosition, msbPosition uint8
+	result                   byte
+}{
+	{"get bottom 3 bits", 0xf2, 0, 2, 0x02},
+	{"get low bit", 0xf0, 0, 0, 0x00},
+	{"lsb and msb out of order", 0xf0, 2, 0, 0x00},
 }
 
 func TestExtractBits(t *testing.T) {
 	var val byte
-	tests := []struct {
-		name                     string
-		data                     byte
-		lsbPosition, msbPosition uint8
-		result                   byte
-	}{
-		{"get bottom 3 bits", 0xf2, 0, 2, 0x02},
-		{"get low bit", 0xf0, 0, 0, 0x00},
-		{"lsb and msb out of order", 0xf0, 2, 0, 0x00},
-	}
-	for _, tt := range tests {
-
-		val = ExtractBits(tt.data, tt.lsbPosition, tt.msbPosition)
-		if val != tt.result {
-			t.Errorf("Test '%v' failed: ExtractBits(0x%x, %v, %v) was 0x%x, should be 0x%x",
-				tt.name,
-				tt.data, tt.lsbPosition, tt.msbPosition,
-				val,
-				tt.result)
-		}
+	for _, tc := range testcasesExtractBits {
+		t.Run(tc.name, func(t *testing.T) {
+			val = ExtractBits(tc.data, tc.lsbPosition, tc.msbPosition)
+			if val != tc.result {
+				t.Errorf("ExtractBits(%x, %x) was %x, should be %x",
+					tc.data, tc.lsbPosition, tc.msbPosition,
+					val,
+					tc.result)
+			}
+		})
 	}
 }
 
-func BenchmarkExtractBitsBottom(t *testing.B) {
-	for i := 0; i < t.N; i++ {
-		ExtractBits(0xf0, 0, 2)
-	}
-}
-
-func BenchmarkExtractBitsLow(t *testing.B) {
-	for i := 0; i < t.N; i++ {
-		ExtractBits(0xf0, 0, 0)
-	}
-}
-
-func BenchmarkExtractBitsOutOfOrder(t *testing.B) {
-	for i := 0; i < t.N; i++ {
-		ExtractBits(0xf0, 2, 0)
+func BenchmarkExtractBits(b *testing.B) {
+	var val byte
+	for _, tc := range testcasesExtractBits {
+		b.Run(tc.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				val = ExtractBits(tc.data, tc.lsbPosition, tc.msbPosition)
+			}
+		})
 	}
 }

--- a/bytearray_operations_test.go
+++ b/bytearray_operations_test.go
@@ -5,147 +5,123 @@ import (
 	"testing"
 )
 
+var testcasesRightShift = []struct {
+	name   string
+	data   []byte
+	shift  uint64
+	result []byte
+}{
+	{"no shift to the right", []byte{0xDA, 0x99, 0xBA}, 0, []byte{0xDA, 0x99, 0xBA}},
+	{"low shift to the right", []byte{0xDA, 0x99, 0xBA}, 1, []byte{0xB5, 0x33, 0x74}},
+	{"middle shift to the right", []byte{0xDA, 0x99, 0xBA}, 8, []byte{0x99, 0xBA, 0x00}},
+	{"high shift to the right", []byte{0xDA, 0x99, 0xBA}, 16, []byte{0xBA, 0x00, 0x00}},
+	{"overflow shift to the right", []byte{0xDA, 0x99, 0xBA}, 24, []byte{0x00, 0x00, 0x00}},
+}
+
 func TestRightShift(t *testing.T) {
 	var val []byte
-	tests := []struct {
-		name   string
-		data   []byte
-		shift  uint64
-		result []byte
-	}{
-		{"no shift to the right", []byte{0xDA, 0x99, 0xBA}, 0, []byte{0xDA, 0x99, 0xBA}},
-		{"low shift to the right", []byte{0xDA, 0x99, 0xBA}, 1, []byte{0xB5, 0x33, 0x74}},
-		{"middle shift to the right", []byte{0xDA, 0x99, 0xBA}, 8, []byte{0x99, 0xBA, 0x00}},
-		{"high shift to the right", []byte{0xDA, 0x99, 0xBA}, 16, []byte{0xBA, 0x00, 0x00}},
-		{"overflow shift to the right", []byte{0xDA, 0x99, 0xBA}, 24, []byte{0x00, 0x00, 0x00}},
-	}
-	for _, tt := range tests {
-
-		val = RightShift(tt.data, tt.shift)
-		if !reflect.DeepEqual(val, tt.result) {
-			t.Errorf("Test '%v' failed: RightShift(0x%x, %v) was 0x%x, should be 0x%x",
-				tt.name,
-				tt.data, tt.shift,
-				val,
-				tt.result)
-		}
+	for _, tc := range testcasesRightShift {
+		t.Run(tc.name, func(t *testing.T) {
+			val = RightShift(tc.data, tc.shift)
+			if !reflect.DeepEqual(val, tc.result) {
+				t.Errorf("RightShift(%x, %v) was %x, should be %x",
+					tc.data, tc.shift,
+					val,
+					tc.result)
+			}
+		})
 	}
 }
 
-func BenchmarkRightShift(t *testing.B) {
-	for i := 0; i < t.N; i++ {
-		RightShift([]byte{0x99, 0xBA}, 1)
+func BenchmarkRightShift(b *testing.B) {
+	var val []byte
+	for _, tc := range testcasesRightShift {
+		b.Run(tc.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				val = RightShift(tc.data, tc.shift)
+			}
+		})
 	}
 }
 
-func BenchmarkRightShiftOver1Byte(t *testing.B) {
-	for i := 0; i < t.N; i++ {
-		RightShift([]byte{0x99, 0xBA}, 9)
-	}
+var testcasesLeftShift = []struct {
+	name   string
+	data   []byte
+	shift  uint64
+	result []byte
+}{
+	{"no shift to the left", []byte{0xDA, 0x99, 0xBA}, 0, []byte{0xDA, 0x99, 0xBA}},
+	{"low shift to the left", []byte{0xDA, 0x99, 0xBA}, 1, []byte{0x6D, 0x4C, 0xDD}},
+	{"middle shift to the left", []byte{0xDA, 0x99, 0xBA}, 8, []byte{0x00, 0xDA, 0x99}},
+	{"high shift to the left", []byte{0xDA, 0x99, 0xBA}, 16, []byte{0x00, 0x00, 0xDA}},
+	{"overflow shift to the left", []byte{0xDA, 0x99, 0xBA}, 24, []byte{0x00, 0x00, 0x00}},
 }
 
 func TestLeftShift(t *testing.T) {
 	var val []byte
-	tests := []struct {
-		name   string
-		data   []byte
-		shift  uint64
-		result []byte
-	}{
-		{"no shift to the left", []byte{0xDA, 0x99, 0xBA}, 0, []byte{0xDA, 0x99, 0xBA}},
-		{"low shift to the left", []byte{0xDA, 0x99, 0xBA}, 1, []byte{0x6D, 0x4C, 0xDD}},
-		{"middle shift to the left", []byte{0xDA, 0x99, 0xBA}, 8, []byte{0x00, 0xDA, 0x99}},
-		{"high shift to the left", []byte{0xDA, 0x99, 0xBA}, 16, []byte{0x00, 0x00, 0xDA}},
-		{"overflow shift to the left", []byte{0xDA, 0x99, 0xBA}, 24, []byte{0x00, 0x00, 0x00}},
-	}
-	for _, tt := range tests {
-
-		val = LeftShift(tt.data, tt.shift)
-		if !reflect.DeepEqual(val, tt.result) {
-			t.Errorf("Test '%v' failed: LeftShift(0x%x, %v) was 0x%x, should be 0x%x",
-				tt.name,
-				tt.data, tt.shift,
-				val,
-				tt.result)
-		}
+	for _, tc := range testcasesLeftShift {
+		t.Run(tc.name, func(t *testing.T) {
+			val = LeftShift(tc.data, tc.shift)
+			if !reflect.DeepEqual(val, tc.result) {
+				t.Errorf("LeftShift(%x, %v) was %x, should be %x",
+					tc.data, tc.shift,
+					val,
+					tc.result)
+			}
+		})
 	}
 }
 
-func BenchmarkLeftShift(t *testing.B) {
-	for i := 0; i < t.N; i++ {
-		LeftShift([]byte{0x99, 0xBA}, 1)
+func BenchmarkLeftShift(b *testing.B) {
+	var val []byte
+	for _, tc := range testcasesLeftShift {
+		b.Run(tc.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				val = LeftShift(tc.data, tc.shift)
+			}
+		})
 	}
 }
 
-func BenchmarkLeftShiftOver1Byte(t *testing.B) {
-	for i := 0; i < t.N; i++ {
-		LeftShift([]byte{0x99, 0xBA}, 9)
-	}
+var testcasesExtractBytes = []struct {
+	name                     string
+	data                     []byte
+	lsbPosition, msbPosition uint64
+	result                   []byte
+}{
+	{"extract nothing", []byte{0xDA, 0x99, 0xBA}, 0, 0, []byte{}},
+	{"extract nothing due to inversed positions", []byte{0xDA, 0x99, 0xBA}, 16, 8, []byte{}},
+	{"extract nothing due to wrong positions", []byte{0xDA, 0x99, 0xBA}, 100, 101, []byte{}},
+	{"extract only in one byte", []byte{0xDA, 0x99, 0xBA}, 5, 7, []byte{0x05}},
+	{"extract one byte over two bytes", []byte{0xDA, 0x99, 0xBA}, 7, 8, []byte{0x03}},
+	{"extract two bytes over three bytes", []byte{0xDA, 0x99, 0xBA}, 6, 17, []byte{0x0A, 0x66}},
+	{"extract three bytes over three bytes", []byte{0xDA, 0x99, 0xBA}, 1, 22, []byte{0x2D, 0x4C, 0xDD}},
+	{"extract all bytes", []byte{0xDA, 0x99, 0xBA}, 0, 23, []byte{0xDA, 0x99, 0xBA}},
+	{"extract all bytes with an overflow position", []byte{0xDA, 0x99, 0xBA}, 0, 100, []byte{0xDA, 0x99, 0xBA}},
 }
 
 func TestExtractBytes(t *testing.T) {
 	var val []byte
-	tests := []struct {
-		name                     string
-		data                     []byte
-		lsbPosition, msbPosition uint64
-		result                   []byte
-	}{
-		{"extract nothing", []byte{0xDA, 0x99, 0xBA}, 0, 0, []byte{}},
-		{"extract nothing due to inversed positions", []byte{0xDA, 0x99, 0xBA}, 16, 8, []byte{}},
-		{"extract nothing due to wrong positions", []byte{0xDA, 0x99, 0xBA}, 100, 101, []byte{}},
-		{"extract only in one byte", []byte{0xDA, 0x99, 0xBA}, 5, 7, []byte{0x05}},
-		{"extract one byte over two bytes", []byte{0xDA, 0x99, 0xBA}, 7, 8, []byte{0x03}},
-		{"extract two bytes over three bytes", []byte{0xDA, 0x99, 0xBA}, 6, 17, []byte{0x0A, 0x66}},
-		{"extract three bytes over three bytes", []byte{0xDA, 0x99, 0xBA}, 1, 22, []byte{0x2D, 0x4C, 0xDD}},
-		{"extract all bytes", []byte{0xDA, 0x99, 0xBA}, 0, 23, []byte{0xDA, 0x99, 0xBA}},
-		{"extract all bytes with an overflow position", []byte{0xDA, 0x99, 0xBA}, 0, 100, []byte{0xDA, 0x99, 0xBA}},
-	}
-	for _, tt := range tests {
-
-		val = ExtractBytes(tt.data, tt.lsbPosition, tt.msbPosition)
-		if !reflect.DeepEqual(val, tt.result) {
-			t.Errorf("Test '%v' failed: ExtractBytes(0x%x, %v, %v) was 0x%x, should be 0x%x",
-				tt.name,
-				tt.data, tt.lsbPosition, tt.msbPosition,
-				val,
-				tt.result)
-		}
+	for _, tc := range testcasesExtractBytes {
+		t.Run(tc.name, func(t *testing.T) {
+			val = ExtractBytes(tc.data, tc.lsbPosition, tc.msbPosition)
+			if !reflect.DeepEqual(val, tc.result) {
+				t.Errorf("ExtractBytes(%x, %v, %v) was %x, should be %x",
+					tc.data, tc.lsbPosition, tc.msbPosition,
+					val,
+					tc.result)
+			}
+		})
 	}
 }
 
-func BenchmarkExtractBytes(t *testing.B) {
-	for i := 0; i < t.N; i++ {
-		ExtractBytes([]byte{0x99, 0xBA}, 7, 8)
-	}
-}
-
-func BenchmarkExtractBytesFrom3Bytes(t *testing.B) {
-	for i := 0; i < t.N; i++ {
-		ExtractBytes([]byte{0x99, 0xBA, 0xDE}, 15, 16)
-	}
-}
-
-func BenchmarkExtract2ByteFrom3Bytes(t *testing.B) {
-	for i := 0; i < t.N; i++ {
-		ExtractBytes([]byte{0x99, 0xBA, 0xDE}, 8, 19)
-	}
-}
-
-func BenchmarkExtractAllBytes(t *testing.B) {
-	for i := 0; i < t.N; i++ {
-		ExtractBytes([]byte{0x99, 0xBA, 0xDE}, 0, 23)
-	}
-}
-
-func BenchmarkComputeSize(t *testing.B) {
-	for i := 0; i < t.N; i++ {
-		computeSize(7, 85)
-	}
-}
-
-func BenchmarkTrim(t *testing.B) {
-	for i := 0; i < t.N; i++ {
-		trim([]byte{0x99, 0xBA, 0x00, 0x02}, 2)
+func BenchmarkExtractBytes(b *testing.B) {
+	var val []byte
+	for _, tc := range testcasesExtractBytes {
+		b.Run(tc.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				val = ExtractBytes(tc.data, tc.lsbPosition, tc.msbPosition)
+			}
+		})
 	}
 }


### PR DESCRIPTION
- Use subtests for tests
- Use subtests for benchmarks
- Use same input (Table-driven) for both
- Run tests and benchmark during Travis builds

Closes #26