### PR TITLE
[#7] support little/big endian operations on a byte array

### DIFF
--- a/big_endian_operations.go
+++ b/big_endian_operations.go
@@ -1,0 +1,76 @@
+package byteness
+
+type bigEndianOperations struct{}
+
+// BigEndianOperations test
+var BigEndianOperations = &bigEndianOperations{}
+
+// Mask apply AND mask to byte array
+func (op *bigEndianOperations) Mask(data, mask []byte) []byte {
+	var dataLength = len(data)
+	if dataLength < 1 {
+		return data
+	}
+
+	var maskLength = len(mask)
+	var operationLength = dataLength
+	var operationCut = dataLength
+	if maskLength > dataLength {
+		operationLength = maskLength
+	}
+
+	result, _ := Mask(rightPad(data, operationLength, 0xFF), rightPad(mask, operationLength, 0xFF))
+	return result[:operationCut]
+}
+
+// InclusiveMerge apply OR operation on two byte arrays
+func (op *bigEndianOperations) InclusiveMerge(data1, data2 []byte) []byte {
+	var data1Length = len(data1)
+	var data2Length = len(data2)
+
+	var operationLength = data1Length
+	if data2Length > data1Length {
+		operationLength = data2Length
+	}
+
+	result, _ := InclusiveMerge(rightPad(data1, operationLength, 0x00), rightPad(data2, operationLength, 0x00))
+	return result
+}
+
+// ExclusiveMerge apply XOR operation on two byte arrays
+func (op *bigEndianOperations) ExclusiveMerge(data1, data2 []byte) []byte {
+	var data1Length = len(data1)
+	var data2Length = len(data2)
+
+	var operationLength = data1Length
+	if data2Length > data1Length {
+		operationLength = data2Length
+	}
+
+	result, _ := ExclusiveMerge(rightPad(data1, operationLength, 0x00), rightPad(data2, operationLength, 0x00))
+	return result
+}
+
+// ExtractBytes get a byte array as subset of another byte array
+func (op *bigEndianOperations) ExtractBytes(data []byte, lsbPosition, msbPosition uint64) []byte {
+	var maxMsb = uint64(byteLength*len(data) - 1)
+
+	if msbPosition <= lsbPosition || lsbPosition > maxMsb {
+		return make([]byte, 0)
+	}
+
+	if msbPosition > maxMsb {
+		msbPosition = maxMsb
+	}
+
+	var result = RightShift(data, maxMsb-msbPosition)
+	var correctiveShift = maxMsb - msbPosition + lsbPosition
+	result = LeftShift(result, correctiveShift)
+
+	var size = computeSize(lsbPosition, msbPosition)
+	return op.trim(result, size)
+}
+
+func (op *bigEndianOperations) trim(data []byte, newSize uint64) []byte {
+	return data[:newSize]
+}

--- a/big_endian_operations_test.go
+++ b/big_endian_operations_test.go
@@ -1,0 +1,169 @@
+package byteness
+
+import (
+	"reflect"
+	"testing"
+)
+
+var testcasesBigEndianOperationsMask = []struct {
+	name   string
+	data   []byte
+	mask   []byte
+	result []byte
+}{
+	{"data and mask of equal length", []byte{0xDA, 0x99, 0xBA}, []byte{0xAD, 0x11, 0xAB}, []byte{0x88, 0x11, 0xAA}},
+	{"data shorter than mask", []byte{0xDA, 0x99, 0xBA}, []byte{0xAD, 0x11, 0xAB, 0x88, 0x11, 0xAA}, []byte{0x88, 0x11, 0xAA}},
+	{"data longer than mask", []byte{0xAD, 0x11, 0xAB, 0x88, 0x11, 0xAA}, []byte{0xDA, 0x99, 0xBA}, []byte{0x88, 0x11, 0xAA, 0x88, 0x11, 0xAA}},
+	{"empty mask on data", []byte{0xDA, 0x99, 0xBA}, []byte{}, []byte{0xDA, 0x99, 0xBA}},
+	{"mask on empty data", []byte{}, []byte{0xAD, 0x11, 0xAB}, []byte{}},
+	{"empty mask on empty data", []byte{}, []byte{}, []byte{}},
+}
+
+func TestBigEndianOperationsMask(t *testing.T) {
+	var val []byte
+	for _, tc := range testcasesBigEndianOperationsMask {
+		t.Run(tc.name, func(t *testing.T) {
+			val = BigEndianOperations.Mask(tc.data, tc.mask)
+			if !reflect.DeepEqual(val, tc.result) {
+				t.Errorf("BigEndianOperations.Mask(%x, %x) was %x, should be %x",
+					tc.data, tc.mask,
+					val,
+					tc.result)
+			}
+		})
+	}
+}
+
+func BenchmarkBigEndianOperationsMask(b *testing.B) {
+	var val []byte
+	for _, tc := range testcasesBigEndianOperationsMask {
+		b.Run(tc.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				val = BigEndianOperations.Mask(tc.data, tc.mask)
+			}
+		})
+	}
+}
+
+var testcasesBigEndianOperationsInclusiveMerge = []struct {
+	name   string
+	data1  []byte
+	data2  []byte
+	result []byte
+}{
+	{"equal length arrays", []byte{0xDA, 0x99, 0xBA}, []byte{0xAD, 0x11, 0xAB}, []byte{0xFF, 0x99, 0xBB}},
+	{"first array longer", []byte{0xAD, 0x11, 0xAB, 0xFF, 0x99, 0xBB}, []byte{0xDA, 0x99, 0xBA}, []byte{0xFF, 0x99, 0xBB, 0xFF, 0x99, 0xBB}},
+	{"second array longer", []byte{0xDA, 0x99, 0xBA}, []byte{0xAD, 0x11, 0xAB, 0xFF, 0x99, 0xBB}, []byte{0xFF, 0x99, 0xBB, 0xFF, 0x99, 0xBB}},
+	{"first array empty", []byte{}, []byte{0xAD, 0x11, 0xAB}, []byte{0xAD, 0x11, 0xAB}},
+	{"second array empty", []byte{0xDA, 0x99, 0xBA}, []byte{}, []byte{0xDA, 0x99, 0xBA}},
+	{"empty arrays", []byte{}, []byte{}, []byte{}},
+}
+
+func TestBigEndianOperationsInclusiveMerge(t *testing.T) {
+	var val []byte
+	for _, tc := range testcasesBigEndianOperationsInclusiveMerge {
+		t.Run(tc.name, func(t *testing.T) {
+			val = BigEndianOperations.InclusiveMerge(tc.data1, tc.data2)
+			if !reflect.DeepEqual(val, tc.result) {
+				t.Errorf("BigEndianOperations.InclusiveMerge(%x, %x) was %x, should be %x",
+					tc.data1, tc.data2,
+					val,
+					tc.result)
+			}
+		})
+	}
+}
+
+func BenchmarkBigEndianOperationsInclusiveMerge(b *testing.B) {
+	var val []byte
+	for _, tc := range testcasesBigEndianOperationsInclusiveMerge {
+		b.Run(tc.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				val = BigEndianOperations.InclusiveMerge(tc.data1, tc.data2)
+			}
+		})
+	}
+}
+
+var testcasesBigEndianOperationsExclusiveMerge = []struct {
+	name   string
+	data1  []byte
+	data2  []byte
+	result []byte
+}{
+	{"equal length arrays", []byte{0xDA, 0x99, 0xBA}, []byte{0xAD, 0x11, 0xAB}, []byte{0x77, 0x88, 0x11}},
+	{"first array longer", []byte{0xAD, 0x11, 0xAB, 0x77, 0x88, 0x11}, []byte{0xDA, 0x99, 0xBA}, []byte{0x77, 0x88, 0x11, 0x77, 0x88, 0x11}},
+	{"second array longer", []byte{0xDA, 0x99, 0xBA}, []byte{0xAD, 0x11, 0xAB, 0x77, 0x88, 0x11}, []byte{0x77, 0x88, 0x11, 0x77, 0x88, 0x11}},
+	{"first array empty", []byte{}, []byte{0xAD, 0x11, 0xAB}, []byte{0xAD, 0x11, 0xAB}},
+	{"second array empty", []byte{0xDA, 0x99, 0xBA}, []byte{}, []byte{0xDA, 0x99, 0xBA}},
+	{"empty arrays", []byte{}, []byte{}, []byte{}},
+}
+
+func TestBigEndianOperationsExclusiveMerge(t *testing.T) {
+	var val []byte
+	for _, tc := range testcasesBigEndianOperationsExclusiveMerge {
+		t.Run(tc.name, func(t *testing.T) {
+			val = BigEndianOperations.ExclusiveMerge(tc.data1, tc.data2)
+			if !reflect.DeepEqual(val, tc.result) {
+				t.Errorf("BigEndianOperations.ExclusiveMerge(%x, %x) was %x, should be %x",
+					tc.data1, tc.data2,
+					val,
+					tc.result)
+			}
+		})
+	}
+}
+
+func BenchmarkBigEndianOperationsExclusiveMerge(b *testing.B) {
+	var val []byte
+	for _, tc := range testcasesBigEndianOperationsExclusiveMerge {
+		b.Run(tc.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				val = BigEndianOperations.ExclusiveMerge(tc.data1, tc.data2)
+			}
+		})
+	}
+}
+
+var testcasesBigEndianOperationsExtractBytes = []struct {
+	name                     string
+	data                     []byte
+	lsbPosition, msbPosition uint64
+	result                   []byte
+}{
+	{"extract nothing", []byte{0xDA, 0x99, 0xBA}, 0, 0, []byte{}},
+	{"extract nothing due to inversed positions", []byte{0xDA, 0x99, 0xBA}, 16, 8, []byte{}},
+	{"extract nothing due to wrong positions", []byte{0xDA, 0x99, 0xBA}, 100, 101, []byte{}},
+	{"extract only in one byte", []byte{0xDA, 0x99, 0xBA}, 5, 7, []byte{0x40}},
+	{"extract one byte over two bytes", []byte{0xDA, 0x99, 0xBA}, 7, 8, []byte{0x40}},
+	{"extract two bytes over three bytes", []byte{0xDA, 0x99, 0xBA}, 6, 17, []byte{0xA6, 0x60}},
+	{"extract three bytes over three bytes", []byte{0xDA, 0x99, 0xBA}, 1, 22, []byte{0xB5, 0x33, 0x74}},
+	{"extract all bytes", []byte{0xDA, 0x99, 0xBA}, 0, 23, []byte{0xDA, 0x99, 0xBA}},
+	{"extract all bytes with an overflow position", []byte{0xDA, 0x99, 0xBA}, 0, 100, []byte{0xDA, 0x99, 0xBA}},
+}
+
+func TestBigEndianOperationsExtractBytes(t *testing.T) {
+	var val []byte
+	for _, tc := range testcasesBigEndianOperationsExtractBytes {
+		t.Run(tc.name, func(t *testing.T) {
+			val = BigEndianOperations.ExtractBytes(tc.data, tc.lsbPosition, tc.msbPosition)
+			if !reflect.DeepEqual(val, tc.result) {
+				t.Errorf("BigEndianOperations.ExtractBytes(%x, %v, %v) was %x, should be %x",
+					tc.data, tc.lsbPosition, tc.msbPosition,
+					val,
+					tc.result)
+			}
+		})
+	}
+}
+
+func BenchmarkBigEndianOperationsExtractBytes(b *testing.B) {
+	var val []byte
+	for _, tc := range testcasesBigEndianOperationsExtractBytes {
+		b.Run(tc.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				val = BigEndianOperations.ExtractBytes(tc.data, tc.lsbPosition, tc.msbPosition)
+			}
+		})
+	}
+}

--- a/bytearray_operations.go
+++ b/bytearray_operations.go
@@ -1,9 +1,12 @@
 package byteness
 
-import "math"
+import (
+	"errors"
+	"math"
+)
 
-// RightShift apply right shift operation to byte array data
-func RightShift(data []byte, shift uint64) []byte {
+// LeftShift apply left shift operation to byte array data
+func LeftShift(data []byte, shift uint64) []byte {
 	if shift == 0 {
 		return data
 	}
@@ -11,7 +14,7 @@ func RightShift(data []byte, shift uint64) []byte {
 	result := make([]byte, dataLength)
 	if shift > byteLength {
 		copy(result, data[1:])
-		result = RightShift(result, shift-byteLength)
+		result = LeftShift(result, shift-byteLength)
 	} else {
 		for i := dataLength - 1; i >= 0; i-- {
 			if i > 0 {
@@ -23,8 +26,8 @@ func RightShift(data []byte, shift uint64) []byte {
 	return result
 }
 
-// LeftShift apply left shift operation to byte array data
-func LeftShift(data []byte, shift uint64) []byte {
+// RightShift apply right shift operation to byte array data
+func RightShift(data []byte, shift uint64) []byte {
 	if shift == 0 {
 		return data
 	}
@@ -32,7 +35,7 @@ func LeftShift(data []byte, shift uint64) []byte {
 	result := make([]byte, dataLength)
 	if shift > byteLength {
 		var shiftedData = append(make([]byte, 1), data[:dataLength-1]...)
-		result = LeftShift(shiftedData, shift-byteLength)
+		result = RightShift(shiftedData, shift-byteLength)
 	} else {
 		for i := 0; i < dataLength; i++ {
 			if i < dataLength-1 {
@@ -44,63 +47,49 @@ func LeftShift(data []byte, shift uint64) []byte {
 	return result
 }
 
-// Mask apply AND mask to byte array
-func Mask(data, mask []byte) []byte {
+// Mask apply AND mask to a byte array, data and mask must have the same size
+func Mask(data, mask []byte) ([]byte, error) {
 	var dataLength = len(data)
-	if dataLength < 1 {
-		return data
-	}
-	result := make([]byte, dataLength)
-	copy(result, data)
-
 	var maskLength = len(mask)
-	var operationLength = maskLength
-	// If mask is longer than data, keep operation to (shorter) data length
-	if maskLength > dataLength {
-		operationLength = dataLength
+	if dataLength != maskLength {
+		return nil, errors.New("data and mask must have the same size")
 	}
-	for i := 1; i < operationLength+1; i++ {
-		result[dataLength-i] &= mask[maskLength-i]
+
+	result := make([]byte, dataLength)
+	for i := 0; i < dataLength; i++ {
+		result[i] = data[i] & mask[i]
 	}
-	return result
+	return result, nil
 }
 
-// InclusiveMerge two byte arrays
-func InclusiveMerge(data1, data2 []byte) []byte {
-	var shorterData = data1
-	var longerData = data2
-	var longerLength = len(data2)
-	if longerLength < len(data1) {
-		shorterData = data2
-		longerData = data1
-		longerLength = len(data1)
+// InclusiveMerge apply OR operation on two byte arrays (must have the same size)
+func InclusiveMerge(data1, data2 []byte) ([]byte, error) {
+	var data1Length = len(data1)
+	var data2Length = len(data2)
+	if data1Length != data2Length {
+		return nil, errors.New("data1 and data2 must have the same size")
 	}
-	result := make([]byte, longerLength)
-	copy(result[longerLength-len(shorterData):], shorterData)
 
-	for i := longerLength - 1; i > -1; i-- {
-		result[i] |= longerData[i]
+	result := make([]byte, data1Length)
+	for i := 0; i < data1Length; i++ {
+		result[i] = data1[i] | data2[i]
 	}
-	return result
+	return result, nil
 }
 
-// ExclusiveMerge two byte arrays
-func ExclusiveMerge(data1, data2 []byte) []byte {
-	var shorterData = data1
-	var longerData = data2
-	var longerLength = len(data2)
-	if longerLength < len(data1) {
-		shorterData = data2
-		longerData = data1
-		longerLength = len(data1)
+// ExclusiveMerge apply XOR operation on two byte arrays (must have the same size)
+func ExclusiveMerge(data1, data2 []byte) ([]byte, error) {
+	var data1Length = len(data1)
+	var data2Length = len(data2)
+	if data1Length != data2Length {
+		return nil, errors.New("data1 and data2 must have the same size")
 	}
-	result := make([]byte, longerLength)
-	copy(result[longerLength-len(shorterData):], shorterData)
 
-	for i := longerLength - 1; i > -1; i-- {
-		result[i] ^= longerData[i]
+	result := make([]byte, data1Length)
+	for i := 0; i < data1Length; i++ {
+		result[i] = data1[i] ^ data2[i]
 	}
-	return result
+	return result, nil
 }
 
 // Not apply NOT operation to byte array
@@ -113,31 +102,33 @@ func Not(data []byte) []byte {
 	return result
 }
 
-// ExtractBytes get a byte array as subset of another byte array
-func ExtractBytes(data []byte, lsbPosition, msbPosition uint64) []byte {
-	var maxMsb = uint64(byteLength*len(data) - 1)
-
-	if msbPosition <= lsbPosition || lsbPosition > maxMsb {
-		return make([]byte, 0)
-	}
-
-	if msbPosition > maxMsb {
-		msbPosition = maxMsb
-	}
-
-	var result = RightShift(data, maxMsb-msbPosition)
-	var correctiveShift = maxMsb + lsbPosition - msbPosition
-	result = LeftShift(result, correctiveShift)
-
-	var size = computeSize(lsbPosition, msbPosition)
-	return trim(result, size)
-}
-
 func computeSize(lsbPosition, msbPosition uint64) uint64 {
 	var byteCount = float64(msbPosition-lsbPosition) / float64(byteLength)
 	return uint64(math.Ceil(byteCount))
 }
 
-func trim(data []byte, newSize uint64) []byte {
-	return data[uint64(len(data))-newSize:]
+func leftPad(data []byte, length int, filler byte) []byte {
+	var dataLength = len(data)
+	if length < 1 || length <= dataLength {
+		return data
+	}
+	var result = make([]byte, length-dataLength, length)
+	for i := range result {
+		result[i] = filler
+	}
+	result = append(result, data...)
+	return result
+}
+
+func rightPad(data []byte, length int, filler byte) []byte {
+	var dataLength = len(data)
+	if length < 1 || length <= dataLength {
+		return data
+	}
+	var result = make([]byte, length-dataLength, length)
+	for i := range result {
+		result[i] = filler
+	}
+	result = append(data, result...)
+	return result
 }

--- a/bytearray_operations_test.go
+++ b/bytearray_operations_test.go
@@ -5,6 +5,45 @@ import (
 	"testing"
 )
 
+var testcasesLeftShift = []struct {
+	name   string
+	data   []byte
+	shift  uint64
+	result []byte
+}{
+	{"no shift to the left", []byte{0xDA, 0x99, 0xBA}, 0, []byte{0xDA, 0x99, 0xBA}},
+	{"low shift to the left", []byte{0xDA, 0x99, 0xBA}, 1, []byte{0xB5, 0x33, 0x74}},
+	{"middle shift to the left", []byte{0xDA, 0x99, 0xBA}, 8, []byte{0x99, 0xBA, 0x00}},
+	{"high shift to the left", []byte{0xDA, 0x99, 0xBA}, 16, []byte{0xBA, 0x00, 0x00}},
+	{"overflow shift to the left", []byte{0xDA, 0x99, 0xBA}, 24, []byte{0x00, 0x00, 0x00}},
+}
+
+func TestLeftShift(t *testing.T) {
+	var val []byte
+	for _, tc := range testcasesLeftShift {
+		t.Run(tc.name, func(t *testing.T) {
+			val = LeftShift(tc.data, tc.shift)
+			if !reflect.DeepEqual(val, tc.result) {
+				t.Errorf("LeftShift(%x, %v) was %x, should be %x",
+					tc.data, tc.shift,
+					val,
+					tc.result)
+			}
+		})
+	}
+}
+
+func BenchmarkLeftShift(b *testing.B) {
+	var val []byte
+	for _, tc := range testcasesLeftShift {
+		b.Run(tc.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				val = LeftShift(tc.data, tc.shift)
+			}
+		})
+	}
+}
+
 var testcasesRightShift = []struct {
 	name   string
 	data   []byte
@@ -12,9 +51,9 @@ var testcasesRightShift = []struct {
 	result []byte
 }{
 	{"no shift to the right", []byte{0xDA, 0x99, 0xBA}, 0, []byte{0xDA, 0x99, 0xBA}},
-	{"low shift to the right", []byte{0xDA, 0x99, 0xBA}, 1, []byte{0xB5, 0x33, 0x74}},
-	{"middle shift to the right", []byte{0xDA, 0x99, 0xBA}, 8, []byte{0x99, 0xBA, 0x00}},
-	{"high shift to the right", []byte{0xDA, 0x99, 0xBA}, 16, []byte{0xBA, 0x00, 0x00}},
+	{"low shift to the right", []byte{0xDA, 0x99, 0xBA}, 1, []byte{0x6D, 0x4C, 0xDD}},
+	{"middle shift to the right", []byte{0xDA, 0x99, 0xBA}, 8, []byte{0x00, 0xDA, 0x99}},
+	{"high shift to the right", []byte{0xDA, 0x99, 0xBA}, 16, []byte{0x00, 0x00, 0xDA}},
 	{"overflow shift to the right", []byte{0xDA, 0x99, 0xBA}, 24, []byte{0x00, 0x00, 0x00}},
 }
 
@@ -44,151 +83,24 @@ func BenchmarkRightShift(b *testing.B) {
 	}
 }
 
-var testcasesLeftShift = []struct {
-	name   string
-	data   []byte
-	shift  uint64
-	result []byte
-}{
-	{"no shift to the left", []byte{0xDA, 0x99, 0xBA}, 0, []byte{0xDA, 0x99, 0xBA}},
-	{"low shift to the left", []byte{0xDA, 0x99, 0xBA}, 1, []byte{0x6D, 0x4C, 0xDD}},
-	{"middle shift to the left", []byte{0xDA, 0x99, 0xBA}, 8, []byte{0x00, 0xDA, 0x99}},
-	{"high shift to the left", []byte{0xDA, 0x99, 0xBA}, 16, []byte{0x00, 0x00, 0xDA}},
-	{"overflow shift to the left", []byte{0xDA, 0x99, 0xBA}, 24, []byte{0x00, 0x00, 0x00}},
-}
-
-func TestLeftShift(t *testing.T) {
-	var val []byte
-	for _, tc := range testcasesLeftShift {
-		t.Run(tc.name, func(t *testing.T) {
-			val = LeftShift(tc.data, tc.shift)
-			if !reflect.DeepEqual(val, tc.result) {
-				t.Errorf("LeftShift(%x, %v) was %x, should be %x",
-					tc.data, tc.shift,
-					val,
-					tc.result)
-			}
-		})
+func TestMaskError(t *testing.T) {
+	val, err := Mask([]byte{0x00, 0x00}, []byte{0x00})
+	if err == nil || val != nil {
+		t.Errorf("Mask with two byte arrays of different size needs to return an error and no value")
 	}
 }
 
-var testcasesMask = []struct {
-	name   string
-	data   []byte
-	mask   []byte
-	result []byte
-}{
-	{"data and mask of equal length", []byte{0xDA, 0x99, 0xBA}, []byte{0xAD, 0x11, 0xAB}, []byte{0x88, 0x11, 0xAA}},
-	{"data shorter than mask", []byte{0xDA, 0x99, 0xBA}, []byte{0xAD, 0x11, 0xAB, 0x88, 0x11, 0xAA}, []byte{0x88, 0x11, 0xAA}},
-	{"data longer than mask", []byte{0xAD, 0x11, 0xAB, 0x88, 0x11, 0xAA}, []byte{0xDA, 0x99, 0xBA}, []byte{0xAD, 0x11, 0xAB, 0x88, 0x11, 0xAA}},
-	{"empty mask on data", []byte{0xDA, 0x99, 0xBA}, []byte{}, []byte{0xDA, 0x99, 0xBA}},
-	{"mask on empty data", []byte{}, []byte{0xAD, 0x11, 0xAB}, []byte{}},
-	{"empty mask on empty data", []byte{}, []byte{}, []byte{}},
-}
-
-func TestMask(t *testing.T) {
-	var val []byte
-	for _, tc := range testcasesMask {
-		t.Run(tc.name, func(t *testing.T) {
-			val = Mask(tc.data, tc.mask)
-			if !reflect.DeepEqual(val, tc.result) {
-				t.Errorf("Mask(%x, %x) was %x, should be %x",
-					tc.data, tc.mask,
-					val,
-					tc.result)
-			}
-		})
+func TestInclusiveMergeError(t *testing.T) {
+	val, err := InclusiveMerge([]byte{0x00, 0x00}, []byte{0x00})
+	if err == nil || val != nil {
+		t.Errorf("InclusiveMerge with two byte arrays of different size needs to return an error and no value")
 	}
 }
 
-func BenchmarkMask(b *testing.B) {
-	var val []byte
-	for _, tc := range testcasesMask {
-		b.Run(tc.name, func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
-				val = Mask(tc.data, tc.mask)
-			}
-		})
-	}
-}
-
-var testcasesInclusiveMerge = []struct {
-	name   string
-	data1  []byte
-	data2  []byte
-	result []byte
-}{
-	{"equal length arrays", []byte{0xDA, 0x99, 0xBA}, []byte{0xAD, 0x11, 0xAB}, []byte{0xFF, 0x99, 0xBB}},
-	{"first array longer", []byte{0xAD, 0x11, 0xAB, 0xFF, 0x99, 0xBB}, []byte{0xDA, 0x99, 0xBA}, []byte{0xAD, 0x11, 0xAB, 0xFF, 0x99, 0xBB}},
-	{"second array longer", []byte{0xDA, 0x99, 0xBA}, []byte{0xAD, 0x11, 0xAB, 0xFF, 0x99, 0xBB}, []byte{0xAD, 0x11, 0xAB, 0xFF, 0x99, 0xBB}},
-	{"first array empty", []byte{}, []byte{0xAD, 0x11, 0xAB}, []byte{0xAD, 0x11, 0xAB}},
-	{"second array empty", []byte{0xDA, 0x99, 0xBA}, []byte{}, []byte{0xDA, 0x99, 0xBA}},
-	{"empty arrays", []byte{}, []byte{}, []byte{}},
-}
-
-func TestInclusiveMerge(t *testing.T) {
-	var val []byte
-	for _, tc := range testcasesInclusiveMerge {
-		t.Run(tc.name, func(t *testing.T) {
-			val = InclusiveMerge(tc.data1, tc.data2)
-			if !reflect.DeepEqual(val, tc.result) {
-				t.Errorf("InclusiveMerge(%x, %x) was %x, should be %x",
-					tc.data1, tc.data2,
-					val,
-					tc.result)
-			}
-		})
-	}
-}
-
-func BenchmarkInclusiveMerge(b *testing.B) {
-	var val []byte
-	for _, tc := range testcasesInclusiveMerge {
-		b.Run(tc.name, func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
-				val = InclusiveMerge(tc.data1, tc.data2)
-			}
-		})
-	}
-}
-
-var testcasesExclusiveMerge = []struct {
-	name   string
-	data1  []byte
-	data2  []byte
-	result []byte
-}{
-	{"equal length arrays", []byte{0xDA, 0x99, 0xBA}, []byte{0xAD, 0x11, 0xAB}, []byte{0x77, 0x88, 0x11}},
-	{"first array longer", []byte{0xAD, 0x11, 0xAB, 0x77, 0x88, 0x11}, []byte{0xDA, 0x99, 0xBA}, []byte{0xAD, 0x11, 0xAB, 0xAD, 0x11, 0xAB}},
-	{"second array longer", []byte{0xAD, 0x11, 0xAB}, []byte{0xAB, 0xCD, 0xEF, 0x77, 0x88, 0x11}, []byte{0xAB, 0xCD, 0xEF, 0xDA, 0x99, 0xBA}},
-	{"first array empty", []byte{}, []byte{0xAD, 0x11, 0xAB}, []byte{0xAD, 0x11, 0xAB}},
-	{"second array empty", []byte{0xDA, 0x99, 0xBA}, []byte{}, []byte{0xDA, 0x99, 0xBA}},
-	{"empty arrays", []byte{}, []byte{}, []byte{}},
-}
-
-func TestExclusiveMerge(t *testing.T) {
-	var val []byte
-	for _, tc := range testcasesExclusiveMerge {
-		t.Run(tc.name, func(t *testing.T) {
-			val = ExclusiveMerge(tc.data1, tc.data2)
-			if !reflect.DeepEqual(val, tc.result) {
-				t.Errorf("ExclusiveMerge(%x, %x) was %x, should be %x",
-					tc.data1, tc.data2,
-					val,
-					tc.result)
-			}
-		})
-	}
-}
-
-func BenchmarkExclusiveMerge(b *testing.B) {
-	var val []byte
-	for _, tc := range testcasesExclusiveMerge {
-		b.Run(tc.name, func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
-				val = ExclusiveMerge(tc.data1, tc.data2)
-			}
-		})
+func TestExclusiveMergeError(t *testing.T) {
+	val, err := ExclusiveMerge([]byte{0x00, 0x00}, []byte{0x00})
+	if err == nil || val != nil {
+		t.Errorf("ExclusiveMerge with two byte arrays of different size needs to return an error and no value")
 	}
 }
 
@@ -227,42 +139,28 @@ func BenchmarkNot(b *testing.B) {
 	}
 }
 
-func BenchmarkLeftShift(b *testing.B) {
-	var val []byte
-	for _, tc := range testcasesLeftShift {
-		b.Run(tc.name, func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
-				val = LeftShift(tc.data, tc.shift)
-			}
-		})
-	}
-}
-
-var testcasesExtractBytes = []struct {
-	name                     string
-	data                     []byte
-	lsbPosition, msbPosition uint64
-	result                   []byte
+var testcasesLeftPad = []struct {
+	name   string
+	data   []byte
+	length int
+	filler byte
+	result []byte
 }{
-	{"extract nothing", []byte{0xDA, 0x99, 0xBA}, 0, 0, []byte{}},
-	{"extract nothing due to inversed positions", []byte{0xDA, 0x99, 0xBA}, 16, 8, []byte{}},
-	{"extract nothing due to wrong positions", []byte{0xDA, 0x99, 0xBA}, 100, 101, []byte{}},
-	{"extract only in one byte", []byte{0xDA, 0x99, 0xBA}, 5, 7, []byte{0x05}},
-	{"extract one byte over two bytes", []byte{0xDA, 0x99, 0xBA}, 7, 8, []byte{0x03}},
-	{"extract two bytes over three bytes", []byte{0xDA, 0x99, 0xBA}, 6, 17, []byte{0x0A, 0x66}},
-	{"extract three bytes over three bytes", []byte{0xDA, 0x99, 0xBA}, 1, 22, []byte{0x2D, 0x4C, 0xDD}},
-	{"extract all bytes", []byte{0xDA, 0x99, 0xBA}, 0, 23, []byte{0xDA, 0x99, 0xBA}},
-	{"extract all bytes with an overflow position", []byte{0xDA, 0x99, 0xBA}, 0, 100, []byte{0xDA, 0x99, 0xBA}},
+	{"lpad to two elements on an smaller array", []byte{0xDA}, 2, 0x00, []byte{0x00, 0xDA}},
+	{"lpad to two elements with a filler on an smaller array", []byte{0xDA}, 2, 0x00, []byte{0x00, 0xDA}},
+	{"lpad to two elements on an empty array", []byte{}, 2, 0x11, []byte{0x11, 0x11}},
+	{"lpad to one element on an larger array", []byte{0xDA, 0x99, 0xBA}, 1, 0x11, []byte{0xDA, 0x99, 0xBA}},
+	{"lpad to negative element size change nothing", []byte{0xDA}, -1, 0x11, []byte{0xDA}},
 }
 
-func TestExtractBytes(t *testing.T) {
+func TestLeftPad(t *testing.T) {
 	var val []byte
-	for _, tc := range testcasesExtractBytes {
+	for _, tc := range testcasesLeftPad {
 		t.Run(tc.name, func(t *testing.T) {
-			val = ExtractBytes(tc.data, tc.lsbPosition, tc.msbPosition)
+			val = leftPad(tc.data, tc.length, tc.filler)
 			if !reflect.DeepEqual(val, tc.result) {
-				t.Errorf("ExtractBytes(%x, %v, %v) was %x, should be %x",
-					tc.data, tc.lsbPosition, tc.msbPosition,
+				t.Errorf("leftPad(%x) was %x, should be %x",
+					tc.data,
 					val,
 					tc.result)
 			}
@@ -270,12 +168,52 @@ func TestExtractBytes(t *testing.T) {
 	}
 }
 
-func BenchmarkExtractBytes(b *testing.B) {
+func BenchmarkLeftPad(b *testing.B) {
 	var val []byte
-	for _, tc := range testcasesExtractBytes {
+	for _, tc := range testcasesLeftPad {
 		b.Run(tc.name, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				val = ExtractBytes(tc.data, tc.lsbPosition, tc.msbPosition)
+				val = leftPad(tc.data, tc.length, tc.filler)
+			}
+		})
+	}
+}
+
+var testcasesRightPad = []struct {
+	name   string
+	data   []byte
+	length int
+	filler byte
+	result []byte
+}{
+	{"rpad to two elements on an smaller array", []byte{0xDA}, 2, 0x00, []byte{0xDA, 0x00}},
+	{"lpad to two elements with a filler on an smaller array", []byte{0xDA}, 2, 0x00, []byte{0xDA, 0x00}},
+	{"rpad to two elements on an empty array", []byte{}, 2, 0x11, []byte{0x11, 0x11}},
+	{"rpad to one element on an larger array", []byte{0xDA, 0x99, 0xBA}, 1, 0x11, []byte{0xDA, 0x99, 0xBA}},
+	{"rpad to negative element size change nothing", []byte{0xDA}, -1, 0x00, []byte{0xDA}},
+}
+
+func TestRightPad(t *testing.T) {
+	var val []byte
+	for _, tc := range testcasesRightPad {
+		t.Run(tc.name, func(t *testing.T) {
+			val = rightPad(tc.data, tc.length, tc.filler)
+			if !reflect.DeepEqual(val, tc.result) {
+				t.Errorf("rightPad(%x) was %x, should be %x",
+					tc.data,
+					val,
+					tc.result)
+			}
+		})
+	}
+}
+
+func BenchmarkRightPad(b *testing.B) {
+	var val []byte
+	for _, tc := range testcasesRightPad {
+		b.Run(tc.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				val = rightPad(tc.data, tc.length, tc.filler)
 			}
 		})
 	}

--- a/little_endian_operations.go
+++ b/little_endian_operations.go
@@ -1,0 +1,77 @@
+package byteness
+
+type littleEndianOperations struct{}
+
+// LittleEndianOperations test
+var LittleEndianOperations = &littleEndianOperations{}
+
+// Mask apply AND mask to a byte array
+func (op *littleEndianOperations) Mask(data, mask []byte) []byte {
+	var dataLength = len(data)
+	if dataLength < 1 {
+		return data
+	}
+
+	var maskLength = len(mask)
+	var operationLength = dataLength
+	var operationCut = 0
+	if maskLength > dataLength {
+		operationLength = maskLength
+		operationCut = operationLength - dataLength
+	}
+
+	result, _ := Mask(leftPad(data, operationLength, 0xFF), leftPad(mask, operationLength, 0xFF))
+	return result[operationCut:]
+}
+
+// InclusiveMerge apply OR operation on two byte arrays
+func (op *littleEndianOperations) InclusiveMerge(data1, data2 []byte) []byte {
+	var data1Length = len(data1)
+	var data2Length = len(data2)
+
+	var operationLength = data1Length
+	if data2Length > data1Length {
+		operationLength = data2Length
+	}
+
+	result, _ := InclusiveMerge(leftPad(data1, operationLength, 0x00), leftPad(data2, operationLength, 0x00))
+	return result
+}
+
+// ExclusiveMerge apply XOR operation on two byte arrays
+func (op *littleEndianOperations) ExclusiveMerge(data1, data2 []byte) []byte {
+	var data1Length = len(data1)
+	var data2Length = len(data2)
+
+	var operationLength = data1Length
+	if data2Length > data1Length {
+		operationLength = data2Length
+	}
+
+	result, _ := ExclusiveMerge(leftPad(data1, operationLength, 0x00), leftPad(data2, operationLength, 0x00))
+	return result
+}
+
+// ExtractBytes get a byte array as subset of another byte array
+func (op *littleEndianOperations) ExtractBytes(data []byte, lsbPosition, msbPosition uint64) []byte {
+	var maxMsb = uint64(byteLength*len(data) - 1)
+
+	if msbPosition <= lsbPosition || lsbPosition > maxMsb {
+		return make([]byte, 0)
+	}
+
+	if msbPosition > maxMsb {
+		msbPosition = maxMsb
+	}
+
+	var result = LeftShift(data, maxMsb-msbPosition)
+	var correctiveShift = maxMsb - msbPosition + lsbPosition
+	result = RightShift(result, correctiveShift)
+
+	var size = computeSize(lsbPosition, msbPosition)
+	return op.trim(result, size)
+}
+
+func (op *littleEndianOperations) trim(data []byte, newSize uint64) []byte {
+	return data[uint64(len(data))-newSize:]
+}

--- a/little_endian_operations_test.go
+++ b/little_endian_operations_test.go
@@ -1,0 +1,169 @@
+package byteness
+
+import (
+	"reflect"
+	"testing"
+)
+
+var testcasesLittleEndianOperationsMask = []struct {
+	name   string
+	data   []byte
+	mask   []byte
+	result []byte
+}{
+	{"data and mask of equal length", []byte{0xDA, 0x99, 0xBA}, []byte{0xAD, 0x11, 0xAB}, []byte{0x88, 0x11, 0xAA}},
+	{"data shorter than mask", []byte{0xDA, 0x99, 0xBA}, []byte{0x88, 0x11, 0xAA, 0xAD, 0x11, 0xAB}, []byte{0x88, 0x11, 0xAA}},
+	{"data longer than mask", []byte{0x88, 0x11, 0xAA, 0xAD, 0x11, 0xAB}, []byte{0xDA, 0x99, 0xBA}, []byte{0x88, 0x11, 0xAA, 0x88, 0x11, 0xAA}},
+	{"empty mask on data", []byte{0xDA, 0x99, 0xBA}, []byte{}, []byte{0xDA, 0x99, 0xBA}},
+	{"mask on empty data", []byte{}, []byte{0xAD, 0x11, 0xAB}, []byte{}},
+	{"empty mask on empty data", []byte{}, []byte{}, []byte{}},
+}
+
+func TestLittleEndianOperationsMask(t *testing.T) {
+	var val []byte
+	for _, tc := range testcasesLittleEndianOperationsMask {
+		t.Run(tc.name, func(t *testing.T) {
+			val = LittleEndianOperations.Mask(tc.data, tc.mask)
+			if !reflect.DeepEqual(val, tc.result) {
+				t.Errorf("LittleEndianOperations.Mask(%x, %x) was %x, should be %x",
+					tc.data, tc.mask,
+					val,
+					tc.result)
+			}
+		})
+	}
+}
+
+func BenchmarkLittleEndianOperationsMask(b *testing.B) {
+	var val []byte
+	for _, tc := range testcasesLittleEndianOperationsMask {
+		b.Run(tc.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				val = LittleEndianOperations.Mask(tc.data, tc.mask)
+			}
+		})
+	}
+}
+
+var testcasesLittleEndianOperationsInclusiveMerge = []struct {
+	name   string
+	data1  []byte
+	data2  []byte
+	result []byte
+}{
+	{"equal length arrays", []byte{0xDA, 0x99, 0xBA}, []byte{0xAD, 0x11, 0xAB}, []byte{0xFF, 0x99, 0xBB}},
+	{"first array longer", []byte{0xFF, 0x99, 0xBB, 0xAD, 0x11, 0xAB}, []byte{0xDA, 0x99, 0xBA}, []byte{0xFF, 0x99, 0xBB, 0xFF, 0x99, 0xBB}},
+	{"second array longer", []byte{0xDA, 0x99, 0xBA}, []byte{0xFF, 0x99, 0xBB, 0xAD, 0x11, 0xAB}, []byte{0xFF, 0x99, 0xBB, 0xFF, 0x99, 0xBB}},
+	{"first array empty", []byte{}, []byte{0xAD, 0x11, 0xAB}, []byte{0xAD, 0x11, 0xAB}},
+	{"second array empty", []byte{0xDA, 0x99, 0xBA}, []byte{}, []byte{0xDA, 0x99, 0xBA}},
+	{"empty arrays", []byte{}, []byte{}, []byte{}},
+}
+
+func TestLittleEndianOperationsInclusiveMerge(t *testing.T) {
+	var val []byte
+	for _, tc := range testcasesLittleEndianOperationsInclusiveMerge {
+		t.Run(tc.name, func(t *testing.T) {
+			val = LittleEndianOperations.InclusiveMerge(tc.data1, tc.data2)
+			if !reflect.DeepEqual(val, tc.result) {
+				t.Errorf("LittleEndianOperations.InclusiveMerge(%x, %x) was %x, should be %x",
+					tc.data1, tc.data2,
+					val,
+					tc.result)
+			}
+		})
+	}
+}
+
+func BenchmarkLittleEndianOperationsInclusiveMerge(b *testing.B) {
+	var val []byte
+	for _, tc := range testcasesLittleEndianOperationsInclusiveMerge {
+		b.Run(tc.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				val = LittleEndianOperations.InclusiveMerge(tc.data1, tc.data2)
+			}
+		})
+	}
+}
+
+var testcasesLittleEndianOperationsExclusiveMerge = []struct {
+	name   string
+	data1  []byte
+	data2  []byte
+	result []byte
+}{
+	{"equal length arrays", []byte{0xDA, 0x99, 0xBA}, []byte{0xAD, 0x11, 0xAB}, []byte{0x77, 0x88, 0x11}},
+	{"first array longer", []byte{0x77, 0x88, 0x11, 0xAD, 0x11, 0xAB}, []byte{0xDA, 0x99, 0xBA}, []byte{0x77, 0x88, 0x11, 0x77, 0x88, 0x11}},
+	{"second array longer", []byte{0xDA, 0x99, 0xBA}, []byte{0x77, 0x88, 0x11, 0xAD, 0x11, 0xAB}, []byte{0x77, 0x88, 0x11, 0x77, 0x88, 0x11}},
+	{"first array empty", []byte{}, []byte{0xAD, 0x11, 0xAB}, []byte{0xAD, 0x11, 0xAB}},
+	{"second array empty", []byte{0xDA, 0x99, 0xBA}, []byte{}, []byte{0xDA, 0x99, 0xBA}},
+	{"empty arrays", []byte{}, []byte{}, []byte{}},
+}
+
+func TestLittleEndianOperationsExclusiveMerge(t *testing.T) {
+	var val []byte
+	for _, tc := range testcasesLittleEndianOperationsExclusiveMerge {
+		t.Run(tc.name, func(t *testing.T) {
+			val = LittleEndianOperations.ExclusiveMerge(tc.data1, tc.data2)
+			if !reflect.DeepEqual(val, tc.result) {
+				t.Errorf("LittleEndianOperations.ExclusiveMerge(%x, %x) was %x, should be %x",
+					tc.data1, tc.data2,
+					val,
+					tc.result)
+			}
+		})
+	}
+}
+
+func BenchmarkLittleEndianOperationsExclusiveMerge(b *testing.B) {
+	var val []byte
+	for _, tc := range testcasesLittleEndianOperationsExclusiveMerge {
+		b.Run(tc.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				val = LittleEndianOperations.ExclusiveMerge(tc.data1, tc.data2)
+			}
+		})
+	}
+}
+
+var testcasesLittleEndianOperationsExtractBytes = []struct {
+	name                     string
+	data                     []byte
+	lsbPosition, msbPosition uint64
+	result                   []byte
+}{
+	{"extract nothing", []byte{0xDA, 0x99, 0xBA}, 0, 0, []byte{}},
+	{"extract nothing due to inversed positions", []byte{0xDA, 0x99, 0xBA}, 16, 8, []byte{}},
+	{"extract nothing due to wrong positions", []byte{0xDA, 0x99, 0xBA}, 100, 101, []byte{}},
+	{"extract only in one byte", []byte{0xDA, 0x99, 0xBA}, 5, 7, []byte{0x05}},
+	{"extract one byte over two bytes", []byte{0xDA, 0x99, 0xBA}, 7, 8, []byte{0x03}},
+	{"extract two bytes over three bytes", []byte{0xDA, 0x99, 0xBA}, 6, 17, []byte{0x0A, 0x66}},
+	{"extract three bytes over three bytes", []byte{0xDA, 0x99, 0xBA}, 1, 22, []byte{0x2D, 0x4C, 0xDD}},
+	{"extract all bytes", []byte{0xDA, 0x99, 0xBA}, 0, 23, []byte{0xDA, 0x99, 0xBA}},
+	{"extract all bytes with an overflow position", []byte{0xDA, 0x99, 0xBA}, 0, 100, []byte{0xDA, 0x99, 0xBA}},
+}
+
+func TestLittleEndianOperationsExtractBytes(t *testing.T) {
+	var val []byte
+	for _, tc := range testcasesLittleEndianOperationsExtractBytes {
+		t.Run(tc.name, func(t *testing.T) {
+			val = LittleEndianOperations.ExtractBytes(tc.data, tc.lsbPosition, tc.msbPosition)
+			if !reflect.DeepEqual(val, tc.result) {
+				t.Errorf("LittleEndianOperations.ExtractBytes(%x, %v, %v) was %x, should be %x",
+					tc.data, tc.lsbPosition, tc.msbPosition,
+					val,
+					tc.result)
+			}
+		})
+	}
+}
+
+func BenchmarkLittleEndianOperationsExtractBytes(b *testing.B) {
+	var val []byte
+	for _, tc := range testcasesLittleEndianOperationsExtractBytes {
+		b.Run(tc.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				val = LittleEndianOperations.ExtractBytes(tc.data, tc.lsbPosition, tc.msbPosition)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Create BigEndianOperations accessor with

  - Mask function,
  - InclusiveMerge function,
  - ExclusiveMerge function,
  - ExtractBytes function.


- Create LittleEndianOperations accessor with

  - Mask function,
  - InclusiveMerge function,
  - ExclusiveMerge function,
  - ExtractBytes function.

- [#31] Fix LeftShift and RightShift functions.

- Add some Endianess-free operations
  - Add Mask function on two arrays of the same size,
  - Add InclusiveMerge function on two arrays of the same size,
  - Add ExclusiveMerge function on two arrays of the same size,
  - Add LeftPad function,
  - Add RightPad function.

Closes #7, #31