### PR TITLE
Examples for Toogle

### DIFF
--- a/example_byteslice_test.go
+++ b/example_byteslice_test.go
@@ -11,7 +11,25 @@ func ExampleReverse() {
 
 func ExampleLPad() {
 	data := []byte{0x55, 0xDA, 0xBA}
-	
+
 	fmt.Printf("%x\n", LPad(data, 5, 0x22))
 	// Output: 222255daba
+}
+
+func ExampleToggle() {
+	data := []byte{0xbb, 0xdb, 0x54}
+	toggle := []byte{0x01, 0x01, 0x01}
+
+	output, _ := Toggle(data, toggle)
+	fmt.Printf("%x\n", output)
+	// Output: bada55
+}
+
+func ExampleToggle_simple() {
+	data := []byte{0x00, 0x01, 0x00}
+	toggle := []byte{0x01, 0x00, 0x01}
+
+	output, _ := Toggle(data, toggle)
+	fmt.Printf("%x\n", output)
+	// Output: 010101
 }


### PR DESCRIPTION
I've added an example for toogle, but I thought it might be clearer if I didn't use `bada55` as the output, what do you think? Also, should Toogle be `Toggle` (not sure if that's a daft question).